### PR TITLE
fix: Use new depends_on macOS syntax

### DIFF
--- a/Casks/l/livewallpaper.rb
+++ b/Casks/l/livewallpaper.rb
@@ -9,7 +9,7 @@ cask "livewallpaper" do
   desc "Open-source live wallpaper application"
   homepage "https://github.com/thusvill/LiveWallpaperMacOS"
 
-  depends_on macos: ">= :sequoia"
+  depends_on macos: :sequoia
 
   app "LiveWallpaper.app"
 


### PR DESCRIPTION
This PR avoids the Homebrew warning (I am on v6):

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :sequoia` instead.
Please report this issue to the thusvill/homebrew-livewallpaper tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/thusvill/homebrew-livewallpaper/Casks/l/livewallpaper.rb:12
```
